### PR TITLE
Use <code> block in string concatenation hint text

### DIFF
--- a/Strings/Concatenation/task.md
+++ b/Strings/Concatenation/task.md
@@ -4,4 +4,4 @@ Combining two strings using the `+` symbol is called concatenation.
   
 Use the `hello` and `world` variables to get a `"Hello World"` string.  
 
-<div class='hint'>Use chained concatenation and one-space string \" \".</div>
+<div class='hint'>Use chained concatenation and one-space string <code>" "</code>.</div>


### PR DESCRIPTION
The code sample in the hint for `concatenation.py` looks strange. Using a `<code>` block makes it more user-friendly, see before & after:

![before](https://user-images.githubusercontent.com/8440079/117279723-47d37300-ae62-11eb-88d3-5ea19b73d658.png)

![after](https://user-images.githubusercontent.com/8440079/117280249-b1ec1800-ae62-11eb-864c-517c10026e08.png)
