### PR TITLE
Fix dictionaries comments

### DIFF
--- a/Data structures/Dictionaries/dicts.py
+++ b/Data structures/Dictionaries/dicts.py
@@ -1,5 +1,5 @@
 # Create a new dictionary, where
-# "John", "Jane" and "Jerard" are keys and numbers are values.
+# "John", "Jane" and "Gerard" are keys and numbers are values.
 phone_book = {"John": 123, "Jane": 234, "Gerard": 345}
 print(phone_book)
 

--- a/Data structures/Dictionaries/task-info.yaml
+++ b/Data structures/Dictionaries/task-info.yaml
@@ -8,7 +8,7 @@ files:
     placeholder_text: '# Add Jared''s number to the phone book'
   - offset: 344
     length: 24
-    placeholder_text: '# Remove Jerard''s number from the phone book'
+    placeholder_text: '# Remove Gerard''s number from the phone book'
   - offset: 394
     length: 18
     placeholder_text: ???


### PR DESCRIPTION
Comments in the Dictionaries task referenced the name (dict key) "Jerard". This was changed in the code to "Gerard" some time ago, but the comment and placeholder were not updated.