### PR TITLE
Correct TODO comment for If-statement

### DIFF
--- a/Condition expressions/If statement/task-info.yaml
+++ b/Condition expressions/If statement/task-info.yaml
@@ -6,7 +6,7 @@ files:
       - offset: 236
         length: 19
         placeholder_text: "# TODO: Write an if statement with a condition to check if\
-      \ the list `tasks` is empty."
+      \ the list `tasks` is not empty."
       - offset: 322
         length: 43
         placeholder_text: "# TODO: check if the list is empty now and print 'Now empty!'\


### PR DESCRIPTION
The TODO comment contradics the task at hand which is to check for a non-empty list.